### PR TITLE
add AJS.contextPath() before url /plugins/servlet/onlyoffice/confluen…

### DIFF
--- a/src/main/resources/js/confluence-previews-plugin/onlyoffice-button.js
+++ b/src/main/resources/js/confluence-previews-plugin/onlyoffice-button.js
@@ -39,7 +39,7 @@ define('cp/component/onlyoffice-button', [
 
             var xhr = new XMLHttpRequest();
 
-            xhr.open("POST", "/plugins/servlet/onlyoffice/confluence/previews/plugin/access", false);
+            xhr.open("POST", AJS.contextPath() + "/plugins/servlet/onlyoffice/confluence/previews/plugin/access", false);
             xhr.send(JSON.stringify({
                  attachmentId: attachmentId
             }));


### PR DESCRIPTION
…ce/previews/plugin/access"
add AJS.contextPath() before url /plugins/servlet/onlyoffice/confluence/previews/plugin/access"，when confluence deployed under a context path,the request url path lost the contextPath part.