### PR TITLE
add contextPath before api url

### DIFF
--- a/src/main/resources/js/confluence-previews-plugin/onlyoffice-button.js
+++ b/src/main/resources/js/confluence-previews-plugin/onlyoffice-button.js
@@ -39,7 +39,7 @@ define('cp/component/onlyoffice-button', [
 
             var xhr = new XMLHttpRequest();
 
-            xhr.open("POST", "/plugins/servlet/onlyoffice/confluence/previews/plugin/access", false);
+            xhr.open("POST", AJS.contextPath() + "/plugins/servlet/onlyoffice/confluence/previews/plugin/access", false);
             xhr.send(JSON.stringify({
                  attachmentId: attachmentId
             }));


### PR DESCRIPTION
if confluence instance have a contextPath,the client rest api url should start with context path